### PR TITLE
Use csv delimiter in getHeadingLine explode

### DIFF
--- a/src/Source/CSVFileSource.php
+++ b/src/Source/CSVFileSource.php
@@ -41,7 +41,8 @@ class CSVFileSource extends AbstractFileSource
 
     public function getHeadingLine(): array
     {
-        return explode(',', $this->getLinesFromFile(1));
+        $settings = $this->getCsvSettings();
+        return explode($settings['delimiter'], $this->getLinesFromFile(1));
     }
 
     protected function getCsvSettings(): array


### PR DESCRIPTION
If you use a CSV-File with another delimiter than ',' - the headline will not be exploded correctly.